### PR TITLE
Add PDF page range extraction utility

### DIFF
--- a/python/pdf_utilities/extract_page_range.py
+++ b/python/pdf_utilities/extract_page_range.py
@@ -1,0 +1,86 @@
+"""Utility to extract a range of pages from one or more PDF files.
+
+Example usages
+---------------
+1. Extract pages 1-3 from ``report.pdf`` into ``out``::
+
+    python python/pdf_utilities/extract_page_range.py report.pdf --start 1 --end 3 --output-dir out
+
+2. Slice pages 2-5 from multiple PDFs and write them to ``slices``::
+
+    python python/pdf_utilities/extract_page_range.py chapter1.pdf chapter2.pdf --start 2 --end 5 --output-dir slices
+
+3. Use shell globbing to process all PDFs in a folder::
+
+    python python/pdf_utilities/extract_page_range.py data/*.pdf --start 10 --end 12 --output-dir subset
+
+"""
+
+import argparse
+from pathlib import Path
+from PyPDF2 import PdfReader, PdfWriter
+
+
+def extract_page_range(pdf_path: Path, start: int, end: int, output_path: Path) -> None:
+    """Extract pages from *start* to *end* from *pdf_path* and write to *output_path*.
+
+    Parameters
+    ----------
+    pdf_path : Path
+        The source PDF file.
+    start : int
+        The first page to extract (1-indexed).
+    end : int
+        The last page to extract (inclusive, 1-indexed).
+    output_path : Path
+        Where the resulting PDF will be written.
+    """
+    reader = PdfReader(str(pdf_path))
+    writer = PdfWriter()
+
+    # Convert to 0-indexed for PyPDF2 and iterate over the requested pages
+    for page in reader.pages[start - 1:end]:
+        writer.add_page(page)
+
+    with output_path.open("wb") as fh:
+        writer.write(fh)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract a range of pages from multiple PDF files.")
+    parser.add_argument(
+        "pdfs",
+        nargs="+",
+        help="One or more source PDF paths",
+    )
+    parser.add_argument(
+        "--start",
+        required=True,
+        type=int,
+        help="First page to extract (1-indexed)",
+    )
+    parser.add_argument(
+        "--end",
+        required=True,
+        type=int,
+        help="Last page to extract (inclusive, 1-indexed)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory where extracted PDFs will be saved",
+    )
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    for pdf in args.pdfs:
+        pdf_path = Path(pdf)
+        out_name = f"{pdf_path.stem}_pages_{args.start}-{args.end}{pdf_path.suffix}"
+        extract_page_range(pdf_path, args.start, args.end, args.output_dir / out_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pdf_utilities/extract_page_range.py
+++ b/python/pdf_utilities/extract_page_range.py
@@ -1,18 +1,19 @@
+#!/usr/bin/env python3
 """Utility to extract a range of pages from one or more PDF files.
 
 Example usages
 ---------------
 1. Extract pages 1-3 from ``report.pdf`` into ``out``::
 
-    python python/pdf_utilities/extract_page_range.py report.pdf --start 1 --end 3 --output-dir out
+    python extract_page_range.py report.pdf --start 1 --end 3 --output-dir out
 
 2. Slice pages 2-5 from multiple PDFs and write them to ``slices``::
 
-    python python/pdf_utilities/extract_page_range.py chapter1.pdf chapter2.pdf --start 2 --end 5 --output-dir slices
+    python extract_page_range.py chapter1.pdf chapter2.pdf --start 2 --end 5 --output-dir slices
 
 3. Use shell globbing to process all PDFs in a folder::
 
-    python python/pdf_utilities/extract_page_range.py data/*.pdf --start 10 --end 12 --output-dir subset
+    python extract_page_range.py data/*.pdf --start 10 --end 12 --output-dir subset
 
 """
 


### PR DESCRIPTION
## Summary
- add `python/pdf_utilities/extract_page_range.py` for slicing page ranges from multiple PDFs into an output directory
- document several example command-line usages in the script

## Testing
- `python -m py_compile python/pdf_utilities/extract_page_range.py`
- `python python/pdf_utilities/extract_page_range.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c7e0cd84c88324a139d3fca77e2447